### PR TITLE
Add mac support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/k1/dns.go
+++ b/k1/dns.go
@@ -199,7 +199,7 @@ func NewDns(one *One, cfg DnsConfig) (*Dns, error) {
 
 	server := &dns.Server{
 		Net:          "udp",
-		Addr:         fmt.Sprintf("%s:%d", one.ip, cfg.DnsPort),
+		Addr:         fmt.Sprintf("%s:%d", "0.0.0.0", cfg.DnsPort),
 		Handler:      dns.HandlerFunc(d.ServeDNS),
 		UDPSize:      int(cfg.DnsPacketSize),
 		ReadTimeout:  time.Duration(cfg.DnsReadTimeout) * time.Second,

--- a/k1/ifce_linux.go
+++ b/k1/ifce_linux.go
@@ -1,0 +1,57 @@
+//
+//   date  : 2016-05-13
+//   author: xjdrew
+//
+
+package k1
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+
+	"github.com/songgao/water"
+)
+
+var MTU = 1500
+
+func execCommand(name, sargs string) error {
+	args := strings.Split(sargs, " ")
+	cmd := exec.Command(name, args...)
+	logger.Infof("exec command: %s %s", name, sargs)
+	return cmd.Run()
+}
+
+func createTun(name string, ip net.IP, mask net.IPMask) (ifce *water.Interface, err error) {
+	ifce, err = water.NewTUN(name)
+	if err != nil {
+		return
+	}
+
+	logger.Infof("create %s", ifce.Name())
+
+	// set ip
+	ipNet := &net.IPNet{
+		IP:   ip,
+		Mask: mask,
+	}
+	sargs := fmt.Sprintf("addr add %s dev %s", ipNet, ifce.Name())
+	err = execCommand("ip", sargs)
+	if err != nil {
+		return
+	}
+
+	// brings the link up
+	sargs = fmt.Sprintf("link set dev %s up mtu %d qlen 1000", ifce.Name(), MTU)
+	err = execCommand("ip", sargs)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func addRoute(name string, subnet *net.IPNet, _ net.IP, _ net.IP) error {
+	sargs := fmt.Sprintf("route add %s dev %s", subnet, name)
+	return execCommand("ip", sargs)
+}

--- a/k1/nat.go
+++ b/k1/nat.go
@@ -118,7 +118,7 @@ func (nat *Nat) allocSession(srcIP, dstIP net.IP, srcPort, dstPort uint16) (bool
 }
 
 func (nat *Nat) clearExpiredSessions(now int64) {
-	if now-nat.lastCheck < NatSessionCheckInterval {
+	if nat.lastCheck < NatSessionCheckInterval {
 		return
 	}
 
@@ -128,7 +128,7 @@ func (nat *Nat) clearExpiredSessions(now int64) {
 
 	nat.lastCheck = now
 	for index, session := range nat.sessions {
-		if session != nil && now-session.lastTouch >= NatSessionLifeSeconds {
+		if session != nil && session.lastTouch >= NatSessionLifeSeconds {
 			nat.sessions[index] = nil
 			nat.tbl.Unmap(session.srcIP, session.srcPort)
 		}

--- a/k1/one.go
+++ b/k1/one.go
@@ -94,7 +94,7 @@ func FromConfig(cfg *KoneConfig) (*One, error) {
 		return nil, err
 	}
 
-	one.tun.AddRoutes(cfg.Route.V)
+	one.tun.AddRoutes(ip, cfg.Route.V)
 
 	// new manager
 	one.manager = NewManager(one, cfg.Manager)

--- a/k1/tun_driver.go
+++ b/k1/tun_driver.go
@@ -44,13 +44,13 @@ func (tun *TunDriver) Serve() error {
 	}
 }
 
-func (tun *TunDriver) AddRoutes(vals []string) {
+func (tun *TunDriver) AddRoutes(ip net.IP, vals []string) {
 	name := tun.ifce.Name()
 	for _, val := range vals {
-		_, subnet, _ := net.ParseCIDR(val)
+		dstip, subnet, _ := net.ParseCIDR(val)
 		if subnet != nil {
-			addRoute(name, subnet)
-			logger.Infof("add route %s to %s", val, name)
+			addRoute(name, subnet, ip, dstip)
+			logger.Infof("add route %s -> %s to %s", val, ip, name)
 		}
 	}
 }


### PR DESCRIPTION
According this [pr](https://github.com/songgao/water/pull/19), water auto add or remove {0,0,0,2} on mac now. I have added mac support. The only problem is that the DNS server must be 127.0.0.1 or your ip address. If you want to set to the tun address, I think we can add a nat, like 10.192.0.1:53 -> 10.192.0.1:5353.